### PR TITLE
feat(server): add tricorder:make-admin Artisan command

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -24,11 +24,18 @@ cp .env.example .env
 php artisan key:generate
 touch database/database.sqlite
 php artisan migrate
+php artisan tricorder:make-admin you@example.com
 php artisan serve
 ```
 
-Then visit [`http://127.0.0.1:8000/up`](http://127.0.0.1:8000/up) — Laravel's
-built-in health endpoint should return `200`.
+`tricorder:make-admin` upserts a Filament-panel user for the given email and
+prints a one-time password to stdout — copy it, then log in at
+[`http://127.0.0.1:8000/admin`](http://127.0.0.1:8000/admin). The command is
+idempotent: re-running it for the same email rotates the password without
+duplicating the user row.
+
+Visit [`http://127.0.0.1:8000/up`](http://127.0.0.1:8000/up) to hit Laravel's
+built-in health endpoint — it should return `200`.
 
 ## Test
 

--- a/apps/server/app/Console/Commands/MakeAdminUser.php
+++ b/apps/server/app/Console/Commands/MakeAdminUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class MakeAdminUser extends Command
+{
+    protected $signature = 'tricorder:make-admin {email : Email address for the panel user} {--name=Admin : Display name for the panel user}';
+
+    protected $description = 'Create or update a Filament panel user and print a one-time password.';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $name = (string) $this->option('name');
+        $password = Str::password(24);
+
+        User::updateOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => Hash::make($password),
+            ],
+        );
+
+        $this->line("email:    {$email}");
+        $this->line("password: {$password}");
+
+        return self::SUCCESS;
+    }
+}

--- a/apps/server/tests/Feature/MakeAdminUserCommandTest.php
+++ b/apps/server/tests/Feature/MakeAdminUserCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('creates a user by email', function () {
+    $this->artisan('tricorder:make-admin', ['email' => 'dri@example.com'])
+        ->assertExitCode(0);
+
+    expect(User::where('email', 'dri@example.com')->count())->toBe(1);
+});
+
+it('is idempotent', function () {
+    $this->artisan('tricorder:make-admin', ['email' => 'dri@example.com'])
+        ->assertExitCode(0);
+
+    $this->artisan('tricorder:make-admin', ['email' => 'dri@example.com'])
+        ->assertExitCode(0);
+
+    expect(User::where('email', 'dri@example.com')->count())->toBe(1);
+});


### PR DESCRIPTION
Ship an idempotent `php artisan tricorder:make-admin {email} {--name=Admin}`
Artisan command so a contributor can reach a logged-in Filament panel in
one pass, without hand-inserting a database row.

- `App\Console\Commands\MakeAdminUser` generates a 24-char random password
  via `Str::password`, hashes it through the `Hash` facade, and upserts a
  `User` row by email (`updateOrCreate`). The plaintext password and email
  are printed to stdout exactly once per run; re-running rotates the
  password without duplicating the row.
- Pest `MakeAdminUserCommandTest` covers both acceptance criteria:
  `it creates a user by email` and `it is idempotent`.
- `apps/server/README.md` install recipe now inserts
  `php artisan tricorder:make-admin you@example.com` between `migrate` and
  `serve`, and points at `/admin` for the panel login.
- Add `tests/Unit/.gitkeep` so `phpunit.xml`'s `Unit` testsuite resolves
  on a fresh clone (scaffold shipped the config but not the directory).

Closes #5.